### PR TITLE
Move executors to docker cloud and unify dev and prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Run start.sh.
 * Clone this repo
 * Create a github Oauth App at https://github.com/settings/developers and put GITHUB_CLIENT_ID GITHUB_CLIENT_SECRET in .env
 * Create and put a SLACK_TOKEN in .env
+* Get the certificates for the docker host to run agents on and point out those files with DOCKER_SERVER_CA_CERTIFICATE DOCKER_CLIENT_CERTIFICATE DOCKER_CLIENT_KEY in .env
+* Configure the DOCKER_URI pointing to the right host in .env
 * And run it as:
 ```bash
 ./bin/docker-compose -f jenkins_compose/compose.yml -f jenkins_compose/prod.yml

--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 ### Setup
 Clone this repo.
-Create a symlink from /var/jenkins_home to /var/lib/docker/volumes/jenkins_compose_jenkins_home/_data
-(This togeather with JAVA_OPTS=-Djava.io.tmpdir=/var/jenkins_home/tmp is
-needed to get docker-custom-build-environment to work in docker in docker setup)
-```bash
-ln -s /var/lib/docker/volumes/jenkins_compose_jenkins_home/_data /var/jenkins_home
-```
 Create a symlink to or clone the repo [bootstrap-docker-builds](https://github.com/SUNET/bootstrap-docker-builds) in /path/to/sunet-jenkins-developer/bootstrap-docker-builds.
 ```bash
 git clone git@github.com:SUNET/bootstrap-docker-builds.git /path/to/sunet-jenkins-developer/

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ Run start.sh.
 ./start.sh
 ```
 
+### How to run (as) in prod?
+* Clone this repo
+* Create a github Oauth App at https://github.com/settings/developers and put GITHUB_CLIENT_ID GITHUB_CLIENT_SECRET in .env
+* Create and put a SLACK_TOKEN in .env
+* And run it as:
+```bash
+./bin/docker-compose -f jenkins_compose/compose.yml -f jenkins_compose/prod.yml
+```
+
 #### Test build your own repos
 Create a folder, and in that folder create a copy of the bootstrap-docker-builds
 job, and edit its enviorment.

--- a/jcasc_configs/jenkins-dev_mode.yaml
+++ b/jcasc_configs/jenkins-dev_mode.yaml
@@ -1,0 +1,15 @@
+jenkins:
+  securityRealm:
+    local:
+      allowsSignup: false
+      users:
+        - id: "admin"
+          password: "admin"
+
+  authorizationStrategy:
+    loggedInUsersCanDoAnything:
+      allowAnonymousRead: false
+
+unclassified:
+  location:
+    url: https://jenkins.jenkins.docker/

--- a/jcasc_configs/jenkins-prod_mode.yaml
+++ b/jcasc_configs/jenkins-prod_mode.yaml
@@ -1,0 +1,24 @@
+jenkins:
+  securityRealm:
+    github:
+      clientID: "${GITHUB_CLIENT_ID}"
+      clientSecret: "${GITHUB_CLIENT_SECRET}"
+      githubApiUri: "https://api.github.com"
+      githubWebUri: "https://github.com"
+      oauthScopes: "read:org,user:email,repo"
+
+  authorizationStrategy:
+    github:
+      adminUserNames: "johanlundberg,glance-"
+      allowAnonymousJobStatusPermission: false
+      allowAnonymousReadPermission: false
+      allowCcTrayPermission: false
+      allowGithubWebHookPermission: false
+      authenticatedUserCreateJobPermission: false
+      authenticatedUserReadPermission: false
+      organizationNames: "SUNET"
+      useRepositoryPermissions: false
+
+unclassified:
+  location:
+    url: https://ci.sunet.se/

--- a/jcasc_configs/jenkins-prod_mode.yaml
+++ b/jcasc_configs/jenkins-prod_mode.yaml
@@ -9,16 +9,32 @@ jenkins:
 
   authorizationStrategy:
     github:
-      adminUserNames: "johanlundberg,glance-"
+      adminUserNames: "${GITHUB_ADMIN_USERNAMES}"
       allowAnonymousJobStatusPermission: false
       allowAnonymousReadPermission: false
-      allowCcTrayPermission: false
-      allowGithubWebHookPermission: false
+      allowCcTrayPermission: true
+      allowGithubWebHookPermission: true
       authenticatedUserCreateJobPermission: false
       authenticatedUserReadPermission: false
       organizationNames: "SUNET"
-      useRepositoryPermissions: false
+      useRepositoryPermissions: true
 
 unclassified:
+  gitHubPluginConfig:
+    hookUrl: "https://ci.sunet.se/github-webhook/"
+    configs:
+    - credentialsId: "sunet"
+      name: "github"
   location:
     url: https://ci.sunet.se/
+    adminAddress: dev@sunet.se
+
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+        - string:
+          # Yea, verbatim copy from previous enviorment
+          description: "leifj personal access token for github"
+          id: "sunet"
+          secret: "${GITHUB_TOKEN}"

--- a/jcasc_configs/jenkins.yaml
+++ b/jcasc_configs/jenkins.yaml
@@ -1,7 +1,8 @@
 # vim: ts=2 sts=2 sw=2 et
 jenkins:
-  numExecutors: 2
-  mode: NORMAL
+  # Don't run jobs on master. Move everything to agents.
+  numExecutors: 0
+  mode: EXCLUSIVE
   crumbIssuer:
     standard:
       excludeClientIPFromCrumb: false
@@ -17,6 +18,40 @@ jenkins:
 
   remotingSecurity:
     enabled: true
+
+  clouds:
+    - docker:
+        name: "Host docker"
+        containerCap: 10
+        dockerApi:
+          dockerHost:
+            uri: "unix:///var/run/docker.sock"
+        templates:
+          - labelString: "jenkins-job"
+            name: "jenkins-job"
+            instanceCapStr: "0"
+            dockerTemplateBase:
+              image: "docker.sunet.se/sunet/jenkins-job"
+              # This is the magic startup command who maps "localhost" to
+              # the docker host machine to have docker run -p xx:yy work
+              # from inside containers.
+              dockerCommand: "/run.sh"
+              # and that run.sh needs a tty to not exit.
+              tty: true
+              # Volumes to run docker-in-docker
+              # and to cache pip downloads
+              volumes:
+                - "/usr/bin/docker:/usr/bin/docker:ro"
+                - "/var/run/docker.sock:/var/run/docker.sock"
+                - "pip_download_cache:/var/cache/jenkins/pip:rw"
+            remoteFs: "/home/jenkins/"
+            connector:
+              attach:
+                user: ""
+            # pullStrategy variable in jcasc
+            # Default to "PROD" value PULL_ALWAYS
+            pullStrategy: "${pullStrategy:-PULL_ALWAYS}"
+
 
 unclassified:
   location:
@@ -116,7 +151,8 @@ jobs:
                   remote {
                       // DEV_MODE is expanded by jcasc
                       if (${DEV_MODE:-false}) {
-                          url('git://git-bootstrap-docker-builds/bootstrap-docker-builds')
+                          // Rely on run.sh localhost mapping, to exposed gitd
+                          url('git://localhost/bootstrap-docker-builds')
                       } else {
                           // When we detect prod, use github directly
                           github('sunet/bootstrap-docker-builds')

--- a/jcasc_configs/jenkins.yaml
+++ b/jcasc_configs/jenkins.yaml
@@ -29,7 +29,7 @@ jenkins:
             name: "jenkins-job"
             instanceCapStr: "0"
             dockerTemplateBase:
-              image: "docker.sunet.se/sunet/jenkins-job"
+              image: "docker.sunet.se/sunet/docker-jenkins-job"
               # This is the magic startup command who maps "localhost" to
               # the docker host machine to have docker run -p xx:yy work
               # from inside containers.

--- a/jcasc_configs/jenkins.yaml
+++ b/jcasc_configs/jenkins.yaml
@@ -21,7 +21,9 @@ jenkins:
         containerCap: 10
         dockerApi:
           dockerHost:
-            uri: "unix:///var/run/docker.sock"
+            credentialsId: "DOCKER_CREDENTAILS"
+            # Credentials are ignored on a unix socket.
+            uri: "${DOCKER_URI:-unix:///var/run/docker.sock}"
         templates:
           - labelString: "jenkins-job"
             name: "jenkins-job"
@@ -96,6 +98,13 @@ credentials:
             id: 'SLACK_TOKEN'
             scope: 'GLOBAL'
             secret: '${SLACK_TOKEN}'
+        - dockerServer:
+            id: "DOCKER_CREDENTAILS"
+            description: "Credentials to access our docker host"
+            scope: 'GLOBAL'
+            serverCaCertificate: '${DOCKER_SERVER_CA_CERTIFICATE}'
+            clientCertificate: '${DOCKER_CLIENT_CERTIFICATE}'
+            clientKeySecret: '${DOCKER_CLIENT_KEY}'
 
 
 jobs:

--- a/jcasc_configs/jenkins.yaml
+++ b/jcasc_configs/jenkins.yaml
@@ -145,12 +145,6 @@ jobs:
                       env('DEV_MODE', '${DEV_MODE}')
                   }
               }
-              credentialsBinding {
-                  string {
-                      variable('SLACK_TOKEN')
-                      credentialsId('SLACK_TOKEN')
-                  }
-              }
           }
           scm {
               git {

--- a/jcasc_configs/jenkins.yaml
+++ b/jcasc_configs/jenkins.yaml
@@ -12,18 +12,6 @@ jenkins:
           - key: PIP_DOWNLOAD_CACHE
             value: /var/cache/jenkins/pip
 
-  # TODO: Move to "develop" context
-  securityRealm:
-    local:
-      allowsSignup: false
-      users:
-        - id: "admin"
-          password: "admin"
-
-  authorizationStrategy:
-    loggedInUsersCanDoAnything:
-      allowAnonymousRead: false
-
   remotingSecurity:
     enabled: true
 
@@ -62,9 +50,6 @@ jenkins:
 
 
 unclassified:
-  location:
-    url: https://jenkins.jenkins.docker/
-
   sshPublisher:
     commonConfig:
       disableAllExec: false

--- a/jcasc_configs/jenkins.yaml
+++ b/jcasc_configs/jenkins.yaml
@@ -12,6 +12,14 @@ jenkins:
           - key: PIP_DOWNLOAD_CACHE
             value: /var/cache/jenkins/pip
 
+  # TODO: Move to "develop" context
+  securityRealm:
+    local:
+      allowsSignup: false
+      users:
+        - id: "admin"
+          password: "admin"
+
   authorizationStrategy:
     loggedInUsersCanDoAnything:
       allowAnonymousRead: false

--- a/jcasc_configs/jenkins.yaml
+++ b/jcasc_configs/jenkins.yaml
@@ -129,6 +129,9 @@ jobs:
               }
           }
           */
+          logRotator {
+              numToKeep(15)
+          }
           triggers {
               // put the job on a cron to run in 1 minute after the rest of the casc configuration finishes loading
               // This is to workaround the fact that queue() doesn't work here, because the queue haven't inited yet.
@@ -137,6 +140,8 @@ jobs:
               def delay = currentDate
               def cron_1_minute = '' + delay.getMinutes() + ' ' + delay.getHours() + ' ' + delay[Calendar.DAY_OF_MONTH] + ' ' + (delay.getMonth()+1) + ' *'
               cron(cron_1_minute)
+              // And after that, run it every 15 minutes to pick up any changes in any github repo
+              cron("H/15  * * * *")
           }
           wrappers {
               // DEV_MODE is expanded by jcasc

--- a/jcasc_configs/jenkins.yaml
+++ b/jcasc_configs/jenkins.yaml
@@ -52,6 +52,10 @@ jenkins:
 
 
 unclassified:
+  gitSCM:
+    createAccountBasedOnEmail: false
+    globalConfigEmail: "dev@sunet.se"
+    globalConfigName: "jenkins"
   sshPublisher:
     commonConfig:
       disableAllExec: false

--- a/jcasc_configs/publish_over_ssh.groovy
+++ b/jcasc_configs/publish_over_ssh.groovy
@@ -12,5 +12,22 @@ configuration.username = "pypi"
 configuration.remoteRootDir = "/home/pypi/packages/"
 // We need to override the implicit default of 0 to the actual default
 configuration.port = configuration.DEFAULT_PORT
+// If we have a /run/secrets/PUBLISH_OVER_SSH_KEY configure it as key
+try {
+	def f = new File("/run/secrets/PUBLISH_OVER_SSH_KEY")
+	configuration.setKey(f.text)
+	//configuration.setKeyPath("/run/secrets/PUBLISH_OVER_SSH_KEY")
+	/*
+	ERROR: Exception when publishing, exception message [Failed to read file - filename [/run/secrets/PUBLISH_OVER_SSH_KEY] (relative to JENKINS_HOME if not absolute). Message: [java.lang.SecurityException: agent may not read /run/secrets/PUBLISH_OVER_SSH_KEY
+	See https://jenkins.io/redirect/security-144 for more details]]
+
+	Either we open that in agent access, or we just set it in jenkins.
+	*/
+	configuration.setOverrideKey(true)
+	println("PUBLISH_OVER_SSH_KEY configured")
+} catch(e) {
+	println("Failed to run setKey(/run/secrets/PUBLISH_OVER_SSH_KEY)")
+	println(e)
+}
 publish_over_ssh.addHostConfiguration(configuration)
 publish_over_ssh.save()

--- a/jenkins_compose/compose.yml
+++ b/jenkins_compose/compose.yml
@@ -10,7 +10,6 @@ services:
       DEV_MODE: "true"
       # TODO: In PROD we need to supply a
       #SLACK_TOKEN: ...
-      JAVA_OPTS: -Djava.io.tmpdir=/var/jenkins_home/tmp
     image: docker.sunet.se/jenkins
     networks:
       jenkins_net:
@@ -27,17 +26,7 @@ services:
       - ../jcasc_configs/publish_over_ssh.groovy:/var/jenkins_home/init.groovy.d/publish_over_ssh.groovy:ro
       - ../jcasc_configs/locale.groovy:/var/jenkins_home/init.groovy.d/locale.groovy:ro
       - ../jcasc_configs/ignored_warnings.groovy:/var/jenkins_home/init.groovy.d/ignored_warnings.groovy:ro
-      - /usr/bin/docker:/usr/bin/docker:ro
       - /var/run/docker.sock:/var/run/docker.sock:rw
-      - jenkins_home:/var/jenkins_home:rw
-    depends_on:
-      - dir_creator
-
-  dir_creator:
-    image: docker.sunet.se/jenkins
-    volumes:
-      - jenkins_home:/var/jenkins_home:rw
-    entrypoint: mkdir /var/jenkins_home/tmp
 
   pound:
     image: docker.sunet.se/pound:latest
@@ -57,18 +46,11 @@ services:
   # TODO: only in dev_mode
   git-bootstrap-docker-builds:
     image: docker.sunet.se/jenkins
-    networks:
-      jenkins_net:
-        aliases:
-          - git-bootstrap-docker-builds
-    expose:
-      - 9418
+    ports:
+      - 9418:9418
     volumes:
       - ../bootstrap-docker-builds:/src/bootstrap-docker-builds:ro
     entrypoint: /usr/bin/git daemon --verbose --base-path=/src/ --export-all
-
-volumes:
-  jenkins_home:
 
 networks:
   jenkins_net:

--- a/jenkins_compose/compose.yml
+++ b/jenkins_compose/compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '3'
+version: '3.7'
 services:
 
   jenkins:

--- a/jenkins_compose/compose.yml
+++ b/jenkins_compose/compose.yml
@@ -5,11 +5,6 @@ services:
   jenkins:
     environment:
       CASC_JENKINS_CONFIG: /var/jenkins_home/casc_configs
-      #TODO: how to make these conditional?
-      pullStrategy: PULL_NEVER
-      DEV_MODE: "true"
-      # TODO: In PROD we need to supply a
-      #SLACK_TOKEN: ...
     image: docker.sunet.se/jenkins
     networks:
       jenkins_net:
@@ -17,12 +12,7 @@ services:
       - 50000
       - 8080
     volumes:
-# Enable named jenkins_home volume if you would like a persistent jenkins_home
-# Othervise, jcasc and job-dsl will populate one.
-#      - jenkins_home:/var/jenkins_home:rw
       - ../jcasc_configs/jenkins.yaml:/var/jenkins_home/casc_configs/jenkins.yaml:ro
-      # TODO: only in dev_mode
-      - ../jcasc_configs/jenkins-dev_mode.yaml:/var/jenkins_home/casc_configs/jenkins-dev_mode.yaml:ro
       - ../jcasc_configs/publish_over_ssh.groovy:/var/jenkins_home/init.groovy.d/publish_over_ssh.groovy:ro
       - ../jcasc_configs/locale.groovy:/var/jenkins_home/init.groovy.d/locale.groovy:ro
       - ../jcasc_configs/ignored_warnings.groovy:/var/jenkins_home/init.groovy.d/ignored_warnings.groovy:ro
@@ -42,15 +32,6 @@ services:
       - "REWRITE_LOCATION=0"
     depends_on:
       - jenkins
-
-  # TODO: only in dev_mode
-  git-bootstrap-docker-builds:
-    image: docker.sunet.se/jenkins
-    ports:
-      - 9418:9418
-    volumes:
-      - ../bootstrap-docker-builds:/src/bootstrap-docker-builds:ro
-    entrypoint: /usr/bin/git daemon --verbose --base-path=/src/ --export-all
 
 networks:
   jenkins_net:

--- a/jenkins_compose/dev.yml
+++ b/jenkins_compose/dev.yml
@@ -1,0 +1,21 @@
+---
+version: '3'
+services:
+
+  jenkins:
+    environment:
+      DEV_MODE: "true"
+      pullStrategy: PULL_NEVER
+      # In PROD we need to supply a SLACK_TOKEN, in dev its defaults to empty
+      #SLACK_TOKEN: "${SLACK_TOKEN}"
+    volumes:
+      # Add config based on mode
+      - ../jcasc_configs/jenkins-dev_mode.yaml:/var/jenkins_home/casc_configs/jenkins-dev_mode.yaml:ro
+
+  git-bootstrap-docker-builds:
+    image: docker.sunet.se/jenkins
+    ports:
+      - 9418:9418
+    volumes:
+      - ../bootstrap-docker-builds:/src/bootstrap-docker-builds:ro
+    entrypoint: /usr/bin/git daemon --verbose --base-path=/src/ --export-all

--- a/jenkins_compose/dev.yml
+++ b/jenkins_compose/dev.yml
@@ -1,5 +1,5 @@
 ---
-version: '3'
+version: '3.7'
 services:
 
   jenkins:

--- a/jenkins_compose/prod.yml
+++ b/jenkins_compose/prod.yml
@@ -1,5 +1,5 @@
 ---
-version: '3'
+version: '3.7'
 services:
 
   jenkins:
@@ -7,13 +7,18 @@ services:
     environment:
       GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:?GITHUB_CLIENT_ID not set, set it in .env}
       GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:?GITHUB_CLIENT_SECRET not set, set it in .env}
-      SLACK_TOKEN: ${SLACK_TOKEN:?SLACK_TOKEN not set, set it in .env}
+      SLACK_TOKEN: ${SLACK_TOKEN?SLACK_TOKEN not set, set it in .env}
+      DOCKER_URI: ${DOCKER_URI?DOCKER_URInot set, set it in .env}
     volumes:
 # Enable named jenkins_home volume if you would like a persistent jenkins_home
 # Othervise, jcasc and job-dsl will populate one.
 #      - jenkins_home:/var/jenkins_home:rw
       # Add config based on mode
       - ../jcasc_configs/jenkins-prod_mode.yaml:/var/jenkins_home/casc_configs/jenkins-prod_mode.yaml:ro
+    secrets:
+      - DOCKER_SERVER_CA_CERTIFICATE
+      - DOCKER_CLIENT_CERTIFICATE
+      - DOCKER_CLIENT_KEY
 
   pound:
     volumes:
@@ -26,3 +31,11 @@ services:
       - 80:80
     environment:
       - "ACME_URL=http://acme-c.sunet.se"
+
+secrets:
+  DOCKER_SERVER_CA_CERTIFICATE:
+    file: ${DOCKER_SERVER_CA_CERTIFICATE:?DOCKER_SERVER_CA_CERTIFICATE not set, set it in .env and point it to the right file}
+  DOCKER_CLIENT_CERTIFICATE:
+    file: ${DOCKER_CLIENT_CERTIFICATE:?DOCKER_CLIENT_CERTIFICATE not set, set it in .env and point it to the right file}
+  DOCKER_CLIENT_KEY:
+    file: ${DOCKER_CLIENT_KEY:?DOCKER_CLIENT_KEY not set, set it in .env and point it to the right file}

--- a/jenkins_compose/prod.yml
+++ b/jenkins_compose/prod.yml
@@ -16,6 +16,7 @@ services:
       # Add config based on mode
       - ../jcasc_configs/jenkins-prod_mode.yaml:/var/jenkins_home/casc_configs/jenkins-prod_mode.yaml:ro
     secrets:
+      - PUBLISH_OVER_SSH_KEY
       - DOCKER_SERVER_CA_CERTIFICATE
       - DOCKER_CLIENT_CERTIFICATE
       - DOCKER_CLIENT_KEY
@@ -33,6 +34,8 @@ services:
       - "ACME_URL=http://acme-c.sunet.se"
 
 secrets:
+  PUBLISH_OVER_SSH_KEY:
+    file: ${PUBLISH_OVER_SSH_KEY?PUBLISH_OVER_SSH_KEY not set, set it in .env and point it to the right file}
   DOCKER_SERVER_CA_CERTIFICATE:
     file: ${DOCKER_SERVER_CA_CERTIFICATE:?DOCKER_SERVER_CA_CERTIFICATE not set, set it in .env and point it to the right file}
   DOCKER_CLIENT_CERTIFICATE:

--- a/jenkins_compose/prod.yml
+++ b/jenkins_compose/prod.yml
@@ -1,0 +1,28 @@
+---
+version: '3'
+services:
+
+  jenkins:
+    # TODO: Move this to secrets?
+    environment:
+      GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:?GITHUB_CLIENT_ID not set, set it in .env}
+      GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:?GITHUB_CLIENT_SECRET not set, set it in .env}
+      SLACK_TOKEN: ${SLACK_TOKEN:?SLACK_TOKEN not set, set it in .env}
+    volumes:
+# Enable named jenkins_home volume if you would like a persistent jenkins_home
+# Othervise, jcasc and job-dsl will populate one.
+#      - jenkins_home:/var/jenkins_home:rw
+      # Add config based on mode
+      - ../jcasc_configs/jenkins-prod_mode.yaml:/var/jenkins_home/casc_configs/jenkins-prod_mode.yaml:ro
+
+  pound:
+    volumes:
+      # TODO: Handle this in some other way?
+      - <%= @dehydrated_bundle %>:/etc/ssl/private/ci.sunet.se.pem
+
+  always-https:
+    image: docker.sunet.se/always-https
+    ports:
+      - 80:80
+    environment:
+      - "ACME_URL=http://acme-c.sunet.se"

--- a/start.sh
+++ b/start.sh
@@ -23,6 +23,6 @@ fi
     fi
 done
 
-./bin/docker-compose -f jenkins_compose/compose.yml rm -s -f
-./bin/docker-compose -f jenkins_compose/compose.yml up "$@"
-./bin/docker-compose -f jenkins_compose/compose.yml logs -tf
+./bin/docker-compose -f jenkins_compose/compose.yml -f jenkins_compose/dev.yml rm -s -f
+./bin/docker-compose -f jenkins_compose/compose.yml -f jenkins_compose/dev.yml up "$@"
+./bin/docker-compose -f jenkins_compose/compose.yml -f jenkins_compose/dev.yml logs -tf


### PR DESCRIPTION
This, together with corresponding changes in bootstrap-docker-builds
moves all our executors to docker-containers. That way we can isolate
the master, and let it only be master.
To use that, we here unifies the dev and prod setups into one common
compose repo from which everything is run.