### PR TITLE
Remove only bit of erb template and use env vars instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Run start.sh.
 * Create and put a SLACK_TOKEN in .env
 * Get the certificates for the docker host to run agents on and point out those files with DOCKER_SERVER_CA_CERTIFICATE DOCKER_CLIENT_CERTIFICATE DOCKER_CLIENT_KEY in .env
 * Configure the DOCKER_URI pointing to the right host in .env
+* Get the certificates for the service and point out that bundle with DEHYDRATED_BUNDLE in .env
 * And run it as:
 ```bash
 ./bin/docker-compose -f jenkins_compose/compose.yml -f jenkins_compose/prod.yml

--- a/jenkins_compose/prod.yml
+++ b/jenkins_compose/prod.yml
@@ -23,8 +23,7 @@ services:
 
   pound:
     volumes:
-      # TODO: Handle this in some other way?
-      - <%= @dehydrated_bundle %>:/etc/ssl/private/ci.sunet.se.pem
+      - ${DEHYDRATED_BUNDLE:?DEHYDRATED_BUNDLE not set, set it in .env}:/etc/ssl/private/ci.sunet.se.pem
 
   always-https:
     image: docker.sunet.se/always-https


### PR DESCRIPTION
Previous setup used a bit of erb template to render in the certificate
bundle path in the config file, while this changes it to use a env-var
instead.

That way, we only have one common way of configuring the service.