### PR TITLE
Final fixes for prod

### DIFF
--- a/jenkins_compose/compose.yml
+++ b/jenkins_compose/compose.yml
@@ -16,7 +16,6 @@ services:
       - ../jcasc_configs/publish_over_ssh.groovy:/var/jenkins_home/init.groovy.d/publish_over_ssh.groovy:ro
       - ../jcasc_configs/locale.groovy:/var/jenkins_home/init.groovy.d/locale.groovy:ro
       - ../jcasc_configs/ignored_warnings.groovy:/var/jenkins_home/init.groovy.d/ignored_warnings.groovy:ro
-      - /var/run/docker.sock:/var/run/docker.sock:rw
 
   pound:
     image: docker.sunet.se/pound:latest

--- a/jenkins_compose/dev.yml
+++ b/jenkins_compose/dev.yml
@@ -11,6 +11,8 @@ services:
     volumes:
       # Add config based on mode
       - ../jcasc_configs/jenkins-dev_mode.yaml:/var/jenkins_home/casc_configs/jenkins-dev_mode.yaml:ro
+      # Add the local docker-socket for running agents on.
+      - /var/run/docker.sock:/var/run/docker.sock:rw
 
   git-bootstrap-docker-builds:
     image: docker.sunet.se/jenkins

--- a/jenkins_compose/prod.yml
+++ b/jenkins_compose/prod.yml
@@ -16,7 +16,7 @@ services:
     volumes:
 # Enable named jenkins_home volume if you would like a persistent jenkins_home
 # Othervise, jcasc and job-dsl will populate one.
-#      - jenkins_home:/var/jenkins_home:rw
+      - jenkins_home:/var/jenkins_home:rw
       # Add config based on mode
       - ../jcasc_configs/jenkins-prod_mode.yaml:/var/jenkins_home/casc_configs/jenkins-prod_mode.yaml:ro
     secrets:
@@ -35,6 +35,9 @@ services:
       - 80:80
     environment:
       - "ACME_URL=http://acme-c.sunet.se"
+
+volumes:
+  jenkins_home:
 
 secrets:
   PUBLISH_OVER_SSH_KEY:


### PR DESCRIPTION
After some discussion we concluded that we would like jenkins_home on a
named volume, so we reuse it in a docker-compose down / up scenario, and
it will help out any future handling of our data.

This also moves the docker.sock to be mointed into the jenkins master only
in dev. This protects anything else running on the master from being
touched by anything running in the jenkins-master container.