### PR TITLE
Verify git signatures on bootstrap-docker-builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Run start.sh.
 * Get the certificates for the docker host to run agents on and point out those files with DOCKER_SERVER_CA_CERTIFICATE DOCKER_CLIENT_CERTIFICATE DOCKER_CLIENT_KEY in .env
 * Configure the DOCKER_URI pointing to the right host in .env
 * Get the certificates for the service and point out that bundle with DEHYDRATED_BUNDLE in .env
+* Point out initial trust key chain with GNUPG_KEYRING in .env
 * And run it as:
 ```bash
 ./bin/docker-compose -f jenkins_compose/compose.yml -f jenkins_compose/prod.yml

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -43,12 +43,12 @@ if [ -n "$compose_dir" ]; then
     VOLUMES="$VOLUMES -v $compose_dir:$compose_dir"
 fi
 if [ -n "$HOME" ]; then
-    VOLUMES="$VOLUMES -v $HOME:$HOME -v $HOME:/root" # mount $HOME in /root to share docker.config
+    VOLUMES="$VOLUMES -v $HOME:$HOME -e HOME" # Pass in HOME to share docker.config and allow ~/-relative paths to work.
 fi
 
 # Only allocate tty if we detect one
 if [ -t 0 -a -t 1 ]; then
-        DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS -t"
+    DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS -t"
 fi
 
 # Always set -i to support piped and terminal input in run/exec

--- a/jcasc_configs/GNUPG_KEYRING_secret.groovy
+++ b/jcasc_configs/GNUPG_KEYRING_secret.groovy
@@ -1,0 +1,23 @@
+import jenkins.model.Jenkins
+import com.cloudbees.plugins.credentials.CredentialsScope
+import com.cloudbees.plugins.credentials.domains.Domain
+import com.cloudbees.plugins.credentials.SecretBytes
+import org.jenkinsci.plugins.plaincredentials.FileCredentials
+import org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl
+
+def store = Jenkins.instance.getExtensionList('com.cloudbees.plugins.credentials.SystemCredentialsProvider')[0].getStore()
+def domain = Domain.global()
+
+File file = new File("/run/secrets/GNUPG_KEYRING")
+SecretBytes sb = SecretBytes.fromBytes(file.getBytes())
+//FileItem fileItem = [ getName: { return "" } ] as FileItem
+FileCredentials secretFile = new FileCredentialsImpl(
+	CredentialsScope.GLOBAL,
+	"GNUPG_KEYRING",
+	"Our default GNUPG pubring.kbx, used for initial trust",
+	null, // Don't use FileItem
+	"pubring.kbx",
+	sb)
+
+store.addCredentials(domain, secretFile)
+

--- a/jcasc_configs/jenkins.yaml
+++ b/jcasc_configs/jenkins.yaml
@@ -109,6 +109,29 @@ credentials:
             serverCaCertificate: '${DOCKER_SERVER_CA_CERTIFICATE}'
             clientCertificate: '${DOCKER_CLIENT_CERTIFICATE}'
             clientKeySecret: '${DOCKER_CLIENT_KEY}'
+# Doesn't work because GNUPG_KEYRING is binary,
+# and we can't pass binary via yaml, it needs to be base64
+# so we create this file in groovy instead.
+#        - file:
+#            id: "GNUPG_KEYRING"
+#            description: "Our default GNUPG pubring.kbx, used for initial trust"
+#            scope: 'GLOBAL'
+#            fileName: "pubring.kbx"
+#            #file: isn't supported
+#            # secretBytes needs base64 encoded data, not binary data as we got here.
+#            #secretBytes: '${GNUPG_KEYRING}'
+
+
+unclassified:
+  globalConfigFiles:
+    configs:
+      - script:
+          id: GPG_WRAPPER
+          name: gpg-wrapper
+          comment: "Our gpg-wrapper to use a gpg keyring provisioned by jenkins into variable GNUPG_KEYRING"
+          content: |
+              #!/bin/bash
+              exec gpg --no-options --no-default-keyring --trustdb-name "$(tempfile)" --keyring "$GNUPG_KEYRING" "$@"
 
 
 jobs:
@@ -154,6 +177,14 @@ jobs:
                       variable('SLACK_TOKEN')
                       credentialsId('SLACK_TOKEN')
                   }
+                  // Provision our keyring to validate against as a file on the agent
+                  file('GNUPG_KEYRING', 'GNUPG_KEYRING')
+              }
+              configFiles {
+                  // And provision our gpg-wrapper to use the keyring GNUPG_KEYRING
+                  custom('GPG_WRAPPER') {
+                      variable('GPG_WRAPPER')
+                  }
               }
           }
           scm {
@@ -172,6 +203,8 @@ jobs:
               }
           }
           steps {
+              // Only run code which we can validate
+              shell('chmod +x "$GPG_WRAPPER" && git -c "gpg.program=$GPG_WRAPPER" verify-commit HEAD')
               jobDsl {
                   targets('github_docker_repos.groovy')
                   additionalClasspath('lib/*.jar')

--- a/jenkins_compose/compose.yml
+++ b/jenkins_compose/compose.yml
@@ -16,6 +16,9 @@ services:
       - ../jcasc_configs/publish_over_ssh.groovy:/var/jenkins_home/init.groovy.d/publish_over_ssh.groovy:ro
       - ../jcasc_configs/locale.groovy:/var/jenkins_home/init.groovy.d/locale.groovy:ro
       - ../jcasc_configs/ignored_warnings.groovy:/var/jenkins_home/init.groovy.d/ignored_warnings.groovy:ro
+      - ../jcasc_configs/GNUPG_KEYRING_secret.groovy:/var/jenkins_home/init.groovy.d/GNUPG_KEYRING_secret.groovy:ro
+    secrets:
+      - GNUPG_KEYRING
 
   pound:
     image: docker.sunet.se/pound:latest

--- a/jenkins_compose/dev.yml
+++ b/jenkins_compose/dev.yml
@@ -21,3 +21,7 @@ services:
     volumes:
       - ../bootstrap-docker-builds:/src/bootstrap-docker-builds:ro
     entrypoint: /usr/bin/git daemon --verbose --base-path=/src/ --export-all
+
+secrets:
+  GNUPG_KEYRING:
+    file: ${GNUPG_KEYRING:-~/.gnupg/pubring.kbx}

--- a/jenkins_compose/prod.yml
+++ b/jenkins_compose/prod.yml
@@ -48,3 +48,5 @@ secrets:
     file: ${DOCKER_CLIENT_CERTIFICATE:?DOCKER_CLIENT_CERTIFICATE not set, set it in .env and point it to the right file}
   DOCKER_CLIENT_KEY:
     file: ${DOCKER_CLIENT_KEY:?DOCKER_CLIENT_KEY not set, set it in .env and point it to the right file}
+  GNUPG_KEYRING:
+    file: ${GNUPG_KEYRING:?GNUPG_KEYRING not set, set it in .env and point it to the right file}

--- a/start.sh
+++ b/start.sh
@@ -24,5 +24,5 @@ fi
 done
 
 ./bin/docker-compose -f jenkins_compose/compose.yml -f jenkins_compose/dev.yml rm -s -f
-./bin/docker-compose -f jenkins_compose/compose.yml -f jenkins_compose/dev.yml up "$@"
+./bin/docker-compose -f jenkins_compose/compose.yml -f jenkins_compose/dev.yml up --abort-on-container-exit --exit-code-from jenkins "$@"
 ./bin/docker-compose -f jenkins_compose/compose.yml -f jenkins_compose/dev.yml logs -tf


### PR DESCRIPTION
This introduces infrastructure and code to provision a gnupg pubkeyring
into jenkins and having git use that keyring on a job to verify HEAD
before actually running that code.