### PR TITLE
Use GITHUB_TOKEN to prevent rate-limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,12 @@ You can omit REPOS, if you would like it to generate jobs for all your repos.
 Both variables contain json as a string.
 Another usecase is to not enter another ORGS, and just filter out the REPOS
 you're interested in and let your local jenkins build those.
+
+
+#### My github requests are failing!
+java.io.IOException: Server returned HTTP response code: 403 for URL: https://api.github.com/
+
+This is because github is rate limiting your api calls. Go to
+https://github.com/settings/tokens and get yourself a token and put it
+as GITHUB_TOKEN in .env, and you don't run into the request api request
+limit as quickly...

--- a/jcasc_configs/jenkins-prod_mode.yaml
+++ b/jcasc_configs/jenkins-prod_mode.yaml
@@ -28,13 +28,3 @@ unclassified:
   location:
     url: https://ci.sunet.se/
     adminAddress: dev@sunet.se
-
-credentials:
-  system:
-    domainCredentials:
-      - credentials:
-        - string:
-            # Yea, verbatim copy from previous enviorment
-            description: "leifj personal access token for github"
-            id: "GITHUB_TOKEN"
-            secret: "${GITHUB_TOKEN}"

--- a/jcasc_configs/jenkins-prod_mode.yaml
+++ b/jcasc_configs/jenkins-prod_mode.yaml
@@ -23,7 +23,7 @@ unclassified:
   gitHubPluginConfig:
     hookUrl: "https://ci.sunet.se/github-webhook/"
     configs:
-    - credentialsId: "sunet"
+    - credentialsId: "GITHUB_TOKEN"
       name: "github"
   location:
     url: https://ci.sunet.se/
@@ -36,5 +36,5 @@ credentials:
         - string:
             # Yea, verbatim copy from previous enviorment
             description: "leifj personal access token for github"
-            id: "sunet"
+            id: "GITHUB_TOKEN"
             secret: "${GITHUB_TOKEN}"

--- a/jcasc_configs/jenkins.yaml
+++ b/jcasc_configs/jenkins.yaml
@@ -120,6 +120,10 @@ credentials:
 #            #file: isn't supported
 #            # secretBytes needs base64 encoded data, not binary data as we got here.
 #            #secretBytes: '${GNUPG_KEYRING}'
+        - string:
+            description: "Github access token"
+            id: "GITHUB_TOKEN"
+            secret: "${GITHUB_TOKEN}"
 
 
 unclassified:
@@ -173,6 +177,10 @@ jobs:
                   }
               }
               credentialsBinding {
+                  string {
+                      variable('GITHUB_TOKEN')
+                      credentialsId('GITHUB_TOKEN')
+                  }
                   // Provision our keyring to validate against as a file on the agent
                   file('GNUPG_KEYRING', 'GNUPG_KEYRING')
               }

--- a/jcasc_configs/jenkins.yaml
+++ b/jcasc_configs/jenkins.yaml
@@ -173,10 +173,6 @@ jobs:
                   }
               }
               credentialsBinding {
-                  string {
-                      variable('SLACK_TOKEN')
-                      credentialsId('SLACK_TOKEN')
-                  }
                   // Provision our keyring to validate against as a file on the agent
                   file('GNUPG_KEYRING', 'GNUPG_KEYRING')
               }

--- a/jenkins_compose/compose.yml
+++ b/jenkins_compose/compose.yml
@@ -5,6 +5,7 @@ services:
   jenkins:
     environment:
       CASC_JENKINS_CONFIG: /var/jenkins_home/casc_configs
+      GITHUB_TOKEN: "${GITHUB_TOKEN}"
     image: docker.sunet.se/sunet/docker-jenkins
     networks:
       jenkins_net:


### PR DESCRIPTION
This exposes our GITHUB_TOKEN to bootstrap-docker-builds so we can use
it as authorisation header in github api requests to prevent us from
getting rate-limited as a anonymous user.